### PR TITLE
Encrypt EBS volumes in CF template.

### DIFF
--- a/contrib/aws/deis.template.json
+++ b/contrib/aws/deis.template.json
@@ -279,15 +279,15 @@
         "BlockDeviceMappings" : [
           {
             "DeviceName" : { "Fn::FindInMap": [ "RootDevices", { "Ref": "EC2VirtualizationType" }, "Name" ] },
-            "Ebs" : { "VolumeSize" : { "Ref": "RootVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" } }
+            "Ebs" : { "VolumeSize" : { "Ref": "RootVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" }, "Encrypted": "true" }
           },
           {
             "DeviceName" : "/dev/xvdf",
-            "Ebs" : { "VolumeSize" : { "Ref": "DockerVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" } }
+            "Ebs" : { "VolumeSize" : { "Ref": "DockerVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" }, "Encrypted": "true" }
           },
           {
             "DeviceName" : "/dev/xvdg",
-            "Ebs" : { "VolumeSize" : { "Ref": "EtcdVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" } }
+            "Ebs" : { "VolumeSize" : { "Ref": "EtcdVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" }, "Encrypted": "true" }
           }
         ]
       }


### PR DESCRIPTION
We need to be able to launch a cluster that `ceph` is using an encrypted EBS volume. I don't see why not to encrypt all the volumes to be extra paranoid seeing as the latency is minimal and IOPs virtually unaffecting according to AWS docs.

@hobbeswalsh @greglook @cyc 
