### PR TITLE
Fix CloudFormation and add Cloudformation tags

### DIFF
--- a/contrib/aws/deis.template.json
+++ b/contrib/aws/deis.template.json
@@ -310,7 +310,7 @@
         "BlockDeviceMappings" : [
           {
             "DeviceName" : { "Fn::FindInMap": [ "RootDevices", { "Ref": "EC2VirtualizationType" }, "Name" ] },
-            "Ebs" : { "VolumeSize" : { "Ref": "RootVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" }, "Encrypted": "true" }
+            "Ebs" : { "VolumeSize" : { "Ref": "RootVolumeSize" }, "VolumeType": { "Ref": "EC2EBSVolumeType" } }
           },
           {
             "DeviceName" : "/dev/xvdf",

--- a/contrib/aws/provision-aws-cluster.sh
+++ b/contrib/aws/provision-aws-cluster.sh
@@ -53,6 +53,7 @@ aws cloudformation create-stack \
     --stack-name $STACK_NAME \
     --parameters "$(<$THIS_DIR/cloudformation.json)" \
     --stack-policy-body "$(<$THIS_DIR/stack_policy.json)" \
+    --tags "$(<$THIS_DIR/tags.json)" \
     $EXTRA_AWS_CLI_ARGS
 
 # loop until the instances are created

--- a/contrib/aws/tags.json
+++ b/contrib/aws/tags.json
@@ -1,0 +1,10 @@
+[
+    {
+        "Key":     "sys",
+        "Value":   "deis"
+    },
+    {
+        "Key":     "team",
+        "Value":   "platform"
+    }
+]


### PR DESCRIPTION
1. Fix broken template. Can't make an EBS volume be encrypted if it's from an unencrypted volume which it is.
2. Add tagging so that it follows our conventions.
