### PR TITLE
Public ELB needs to be "internet-facing" to work as designed

### DIFF
--- a/contrib/aws/deis.template.json
+++ b/contrib/aws/deis.template.json
@@ -328,7 +328,7 @@
       "Condition": "UsePublicELB",
       "DependsOn" : "GatewayToInternet",
       "Properties": {
-        "Scheme" : {"Ref": "ELBScheme"},
+        "Scheme" : "internet-facing",
         "HealthCheck": {
           "HealthyThreshold": "4",
           "Interval": "15",


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-elb.html#cfn-ec2-elb-scheme

We launching it using the same `{"Ref": "ELBScheme"}` from the existing ELB which is for our private traffic. We want this property of `"internet-facing"` on the Public ELB, while the private will stay `"internal"`, thus this change.

cc @cyc 
